### PR TITLE
Clean deployment shell scripts and heat templates

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -30,8 +30,6 @@ fi
 if [[ $CONTAINERS -eq 1 ]]; then
     openstack tripleo container image prepare default \
       --output-env-file $HOME/containers-prepare-parameters.yaml
-    # hack add last known working ceph tag version in my environment
-    sed -i 's/ceph_tag:.*/ceph_tag:\ v3.1.0-stable-3.1-luminous-centos-7-x86_64/g' $HOME/containers-prepare-parameters.yaml
 fi
 
 if [[ $CEPH_PREP -eq 1 ]]; then

--- a/create-compute-stack-env.sh
+++ b/create-compute-stack-env.sh
@@ -20,5 +20,7 @@ cp ~/tripleo-undercloud-passwords.yaml $DIR/passwords.yaml
 echo "parameter_defaults:" > $DIR/oslo.yaml
 echo "  ComputeExtraConfig:" >> $DIR/oslo.yaml
 egrep "oslo.*password"  /etc/puppet/hieradata/service_configs.json | sed -e s/\"//g -e s/,//g >> $DIR/oslo.yaml
+echo "    oslo_messaging_notify_use_ssl: false" >> $DIR/oslo.yaml
+echo "    oslo_messaging_rpc_use_ssl: false" >> $DIR/oslo.yaml
 
 tar cvfz $DIR.tar.gz $DIR/

--- a/environments/standalone-edge.yaml
+++ b/environments/standalone-edge.yaml
@@ -3,7 +3,6 @@ resource_registry:
   OS::TripleO::Network::Ports::ControlPlaneVipPort: /root/templates/deployed-server/deployed-neutron-port.yaml
   OS::TripleO::Network::Ports::ControlPlanePort: /root/templates/deployed-server/deployed-neutron-port.yaml
   OS::TripleO::Compute::Net::SoftwareConfig: /root/templates/net-config-standalone.yaml
-  # OS::TripleO::NodeExtraConfigPost: /root/templates/extraconfig/post_deploy/standalone_post.yaml
 
   # Disable non-openstack services that are enabled by default
   OS::TripleO::Services::HAproxy: OS::Heat::None

--- a/standalone-central.sh
+++ b/standalone-central.sh
@@ -7,34 +7,24 @@ export GATEWAY=192.168.122.1
 
 cat <<EOF > $HOME/standalone_parameters.yaml
 parameter_defaults:
-  CertmongerCA: local
   CloudName: $IP
-  ContainerImagePrepare:
-  - set:
-      ceph_image: daemon
-      ceph_namespace: docker.io/ceph
-      ceph_tag: v3.1.0-stable-3.1-luminous-centos-7-x86_64
-      name_prefix: centos-binary-
-      name_suffix: ''
-      namespace: docker.io/tripleomaster
-      neutron_driver: null
-      tag: current-tripleo
-    tag_from_label: rdo_version
-  # default gateway
+  StandaloneHomeDir: $HOME
+  DeploymentUser: $USER
+  DockerInsecureRegistryAddress:
+  - $IP:8787
   ControlPlaneStaticRoutes:
     - ip_netmask: 0.0.0.0/0
       next_hop: $GATEWAY
       default: true
-  Debug: true
-  DeploymentUser: $USER
+  NeutronPublicInterface: $INTERFACE
+  # static
   DnsServers:
     - 8.8.4.4
     - 8.8.8.8
+  CertmongerCA: local
+  Debug: true
   # needed for vip & pacemaker
   KernelIpNonLocalBind: 1
-  DockerInsecureRegistryAddress:
-  - $IP:8787
-  NeutronPublicInterface: $INTERFACE
   # domain name used by the host
   NeutronDnsDomain: localdomain
   # re-use ctlplane bridge for public net
@@ -42,13 +32,12 @@ parameter_defaults:
   NeutronPhysicalBridge: br-ctlplane
   # enable to force metadata for public net
   #NeutronEnableForceMetadata: true
-  StandaloneEnableRoutedNetworks: false
-  StandaloneHomeDir: $HOME
-  StandaloneLocalMtu: 1400
   # Needed if running in a VM
-  StandaloneExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::libvirt_virt_type: qemu
+  NovaComputeLibvirtType: qemu
+
+  # role specific
+  StandaloneEnableRoutedNetworks: false
+  StandaloneLocalMtu: 1400
 EOF
 
 if [[ ! -d ~/templates ]]; then
@@ -60,6 +49,7 @@ sudo openstack tripleo deploy \
   --local-ip=$IP/$NETMASK \
   -e ~/templates/environments/standalone.yaml \
   -r ~/templates/roles/Standalone.yaml \
+  -e $HOME/containers-prepare-parameters.yaml \
   -e $HOME/standalone_parameters.yaml \
   --output-dir $HOME \
   --standalone \

--- a/standalone-edge.sh
+++ b/standalone-edge.sh
@@ -7,34 +7,24 @@ export GATEWAY=192.168.122.1
 
 cat <<EOF > $HOME/standalone_parameters.yaml
 parameter_defaults:
-  CertmongerCA: local
   CloudName: $IP
-  ContainerImagePrepare:
-  - set:
-      ceph_image: daemon
-      ceph_namespace: docker.io/ceph
-      ceph_tag: v3.1.0-stable-3.1-luminous-centos-7-x86_64
-      name_prefix: centos-binary-
-      name_suffix: ''
-      namespace: docker.io/tripleomaster
-      neutron_driver: null
-      tag: current-tripleo
-    tag_from_label: rdo_version
-  # default gateway
+  ComputeHomeDir: $HOME
+  DeploymentUser: $USER
+  DockerInsecureRegistryAddress:
+  - $IP:8787
   ControlPlaneStaticRoutes:
     - ip_netmask: 0.0.0.0/0
       next_hop: $GATEWAY
       default: true
-  Debug: true
-  DeploymentUser: $USER
+  NeutronPublicInterface: $INTERFACE
+  # static
   DnsServers:
     - 8.8.4.4
     - 8.8.8.8
+  CertmongerCA: local
+  Debug: true
   # needed for vip & pacemaker
   KernelIpNonLocalBind: 1
-  DockerInsecureRegistryAddress:
-  - $IP:8787
-  NeutronPublicInterface: $INTERFACE
   # domain name used by the host
   NeutronDnsDomain: localdomain
   # re-use ctlplane bridge for public net
@@ -42,19 +32,12 @@ parameter_defaults:
   NeutronPhysicalBridge: br-ctlplane
   # enable to force metadata for public net
   #NeutronEnableForceMetadata: true
-  ComputeEnableRoutedNetworks: false
-  ComputeHomeDir: $HOME
-  ComputeLocalMtu: 1400
   # Needed if running in a VM
-  ComputeExtraConfig:
-    nova::compute::libvirt::services::libvirt_virt_type: qemu
-    nova::compute::libvirt::libvirt_virt_type: qemu
-    # oslo_messaging_notify_node_names: standalone-central.internalapi.localdomain
-    # oslo_messaging_rpc_node_names: standalone-central.internalapi.localdomain
-    # oslo_messaging_notify_password: JfMz1jMaQ5rtT9UxvgbjntizI
-    # oslo_messaging_rpc_password: JfMz1jMaQ5rtT9UxvgbjntizI
-    oslo_messaging_notify_use_ssl: false
-    oslo_messaging_rpc_use_ssl: false
+  NovaComputeLibvirtType: qemu
+
+  # role specific
+  ComputeEnableRoutedNetworks: false
+  ComputeLocalMtu: 1400
 EOF
 
 if [[ ! -d ~/templates ]]; then
@@ -67,6 +50,7 @@ sudo openstack tripleo deploy \
   -e ~/templates/environments/standalone.yaml \
   -r ~/edge/roles/Standalone-Compute.yaml \
   -e ~/edge/environments/standalone-edge.yaml \
+  -e $HOME/containers-prepare-parameters.yaml \
   -e ~/standalone_parameters.yaml \
   -e ~/export_control_plane/passwords.yaml \
   -e ~/export_control_plane/endpoint-map.json \


### PR DESCRIPTION
- remove sed hack to set ceph3.1 container
- remove commented out path to unused post_deploy env file
- add two olso options to oslo.yaml instead of having them in standalone-edge.sh
- switch from direct hiera overrides NovaComputeLibvirtType
- use containers-prepare-parameters.yaml instead of hard coding
- remove oslo_* comments and needed *_ssl params are now in oslo.yaml
- reorganize parmeter list in created standalone_parameters.yaml by type; using env variables, static, and role specific