### PR TITLE
Clean heat environment files and improve testing workflow

### DIFF
--- a/ansible/clone.yml
+++ b/ansible/clone.yml
@@ -83,11 +83,11 @@
           if [[ $SSH_GIT_CHECKOUT -eq 1 ]]; then
             ssh-keyscan github.com >> ~/.ssh/known_hosts
             git clone git@github.com:/fultonj/oooq.git
-            git clone git@github.com:/fultonj/edge.git
+            git clone -b testing git@github.com:/fultonj/edge.git
             ln -s oooq/git-init.sh
             bash git-init.sh
           else
-            git clone https://github.com/fultonj/edge.git
+            git clone -b testing https://github.com/fultonj/edge.git
             export THT_REVIEW={{ tht_review }}
             if [[ ! -z $THT_REVIEW ]]; then
               echo "Downloading unmerged archive of THT review"

--- a/ansible/clone.yml
+++ b/ansible/clone.yml
@@ -28,7 +28,7 @@
 - hosts: over
   vars:
     ssh_git_checkout: 0
-    tht_review: https://review.openstack.org/changes/613793/revisions/b201df7257f700edab56e13d2d85e503624e634a/archive?format=tgz
+    tht_review: ""
   tasks:
     - name: install packages
       yum:
@@ -97,6 +97,9 @@
               tar xf templates.tar.gz
               rm -f templates.tar.gz
               popd
+            else
+              git clone https://github.com/openstack/tripleo-heat-templates.git
+              ln -s tripleo-heat-templates templates
             fi
           fi
           ln -s edge/bootstrap.sh 0_bootstrap.sh

--- a/ansible/inventory_one.yml
+++ b/ansible/inventory_one.yml
@@ -1,0 +1,10 @@
+---
+[over]
+overcloud0 ansible_user=root
+overcloud1 ansible_user=root
+
+[central]
+overcloud0
+
+[edge]
+overcloud1

--- a/ansible/inventory_two.yml
+++ b/ansible/inventory_two.yml
@@ -1,0 +1,10 @@
+---
+[over]
+overcloud0 ansible_user=root
+overcloud2 ansible_user=root
+
+[central]
+overcloud0
+
+[edge]
+overcloud2

--- a/environments/standalone-edge.yaml
+++ b/environments/standalone-edge.yaml
@@ -1,5 +1,8 @@
 resource_registry:
+  OS::TripleO::Network::Ports::RedisVipPort: /root/templates/network/ports/noop.yaml
+  OS::TripleO::Network::Ports::ControlPlaneVipPort: /root/templates/deployed-server/deployed-neutron-port.yaml
   OS::TripleO::Network::Ports::ControlPlanePort: /root/templates/deployed-server/deployed-neutron-port.yaml
+  OS::TripleO::Compute::Net::SoftwareConfig: /root/templates/net-config-standalone.yaml
   OS::TripleO::Services::CACerts: OS::Heat::None
   OS::TripleO::Services::CinderApi: OS::Heat::None
   OS::TripleO::Services::CinderScheduler: OS::Heat::None

--- a/environments/standalone-edge.yaml
+++ b/environments/standalone-edge.yaml
@@ -1,27 +1,11 @@
 resource_registry:
-  OS::TripleO::Network::Ports::RedisVipPort: /root/templates/network/ports/noop.yaml
-  OS::TripleO::Network::Ports::ControlPlaneVipPort: /root/templates/deployed-server/deployed-neutron-port.yaml
   OS::TripleO::Network::Ports::ControlPlanePort: /root/templates/deployed-server/deployed-neutron-port.yaml
-  OS::TripleO::Compute::Net::SoftwareConfig: /root/templates/net-config-standalone.yaml
-
-  # Disable non-openstack services that are enabled by default
-  OS::TripleO::Services::HAproxy: OS::Heat::None
-  OS::TripleO::Services::Keepalived: OS::Heat::None
-  OS::TripleO::Services::Kubernetes::Master: OS::Heat::None
-  OS::TripleO::Services::Kubernetes::Worker: OS::Heat::None
-
-  # By default we only want the following services to be enabled:
-  # * Core services for a compute
-  # * Nova Compute and related
-  # * Neutron agent and related
   OS::TripleO::Services::CACerts: OS::Heat::None
   OS::TripleO::Services::CinderApi: OS::Heat::None
   OS::TripleO::Services::CinderScheduler: OS::Heat::None
   OS::TripleO::Services::CinderVolume: OS::Heat::None
   OS::TripleO::Services::Clustercheck: OS::Heat::None
   OS::TripleO::Services::GlanceApi: OS::Heat::None
-  OS::TripleO::Services::GlanceRegistry: OS::Heat::None
-  OS::TripleO::Services::HAproxy: OS::Heat::None
   OS::TripleO::Services::Horizon: OS::Heat::None
   OS::TripleO::Services::Keystone: OS::Heat::None
   OS::TripleO::Services::Memcached: OS::Heat::None
@@ -43,76 +27,5 @@ resource_registry:
   OS::TripleO::Services::OsloMessagingRpc: OS::Heat::None
   OS::TripleO::Services::Redis: OS::Heat::None
   OS::TripleO::Services::SwiftProxy: OS::Heat::None
-  OS::TripleO::Services::SwiftStorage: OS::Heat::None
   OS::TripleO::Services::SwiftRingBuilder: OS::Heat::None
-
-  # so we disable any other OpenStacks that would normally be enabled.
-  # Aodh
-  OS::TripleO::Services::AodhApi: OS::Heat::None
-  OS::TripleO::Services::AodhEvaluator: OS::Heat::None
-  OS::TripleO::Services::AodhEvaluator: OS::Heat::None
-  OS::TripleO::Services::AodhListener: OS::Heat::None
-  OS::TripleO::Services::AodhNotifier: OS::Heat::None
-  # Barbican
-  OS::TripleO::Services::BarbicanApi: OS::Heat::None
-  OS::TripleO::Services::BarbicanBackendDogtag: OS::Heat::None
-  OS::TripleO::Services::BarbicanBackendKmip: OS::Heat::None
-  OS::TripleO::Services::BarbicanBackendPkcs11Crypto: OS::Heat::None
-  OS::TripleO::Services::BarbicanBackendSimpleCrypto: OS::Heat::None
-  # Ceilometer
-  OS::TripleO::Services::CeilometerAgentCentral: OS::Heat::None
-  OS::TripleO::Services::CeilometerAgentNotification: OS::Heat::None
-  OS::TripleO::Services::ComputeCeilometerAgent: OS::Heat::None
-  # Congress
-  OS::TripleO::Services::Congress: OS::Heat::None
-  # Designate
-  OS::TripleO::Services::DesignateApi: OS::Heat::None
-  OS::TripleO::Services::DesignateCentral: OS::Heat::None
-  OS::TripleO::Services::DesignateMDNS: OS::Heat::None
-  OS::TripleO::Services::DesignateProducer: OS::Heat::None
-  OS::TripleO::Services::DesignateSink: OS::Heat::None
-  OS::TripleO::Services::DesignateWorker: OS::Heat::None
-  # Gnocchi
-  OS::TripleO::Services::GnocchiApi: OS::Heat::None
-  OS::TripleO::Services::GnocchiMetricd: OS::Heat::None
-  OS::TripleO::Services::GnocchiStatsd: OS::Heat::None
-  # Heat
-  OS::TripleO::Services::HeatApi: OS::Heat::None
-  OS::TripleO::Services::HeatApiCfn: OS::Heat::None
-  OS::TripleO::Services::HeatApiCloudwatch: OS::Heat::None
-  OS::TripleO::Services::HeatEngine: OS::Heat::None
-  # Ironic
-  OS::TripleO::Services::IronicApi: OS::Heat::None
-  OS::TripleO::Services::IronicConductor: OS::Heat::None
-  OS::TripleO::Services::IronicInspector: OS::Heat::None
-  OS::TripleO::Services::IronicNeutronAgent: OS::Heat::None
-  OS::TripleO::Services::IronicPxe: OS::Heat::None
-  # Manila
-  OS::TripleO::Services::ManilaApi: OS::Heat::None
-  OS::TripleO::Services::ManilaBackendCephFs: OS::Heat::None
-  OS::TripleO::Services::ManilaBackendIsilon: OS::Heat::None
-  OS::TripleO::Services::ManilaBackendNetapp: OS::Heat::None
-  OS::TripleO::Services::ManilaBackendUnity: OS::Heat::None
-  OS::TripleO::Services::ManilaBackendVMAX: OS::Heat::None
-  OS::TripleO::Services::ManilaBackendVNX: OS::Heat::None
-  OS::TripleO::Services::ManilaScheduler: OS::Heat::None
-  OS::TripleO::Services::ManilaShare: OS::Heat::None
-  # Mistral
-  OS::TripleO::Services::MistralApi: OS::Heat::None
-  OS::TripleO::Services::MistralEngine: OS::Heat::None
-  OS::TripleO::Services::MistralEventEngine: OS::Heat::None
-  OS::TripleO::Services::MistralExecutor: OS::Heat::None
-  # Panko
-  OS::TripleO::Services::PankoApi: OS::Heat::None
-  # Sahara
-  OS::TripleO::Services::SaharaApi: OS::Heat::None
-  OS::TripleO::Services::SaharaEngine: OS::Heat::None
-  # Tacker
-  OS::TripleO::Services::Tacker: OS::Heat::None
-  # Zaqar
-  OS::TripleO::Services::Zaqar: OS::Heat::None
-
-parameter_defaults:
-  StackAction: CREATE
-  SoftwareConfigTransport: POLL_SERVER_HEAT
-  EnablePackageInstall: true
+  OS::TripleO::Services::SwiftStorage: OS::Heat::None

--- a/environments/standalone-edge.yaml
+++ b/environments/standalone-edge.yaml
@@ -1,6 +1,4 @@
 resource_registry:
-  OS::TripleO::Network::Ports::RedisVipPort: /root/templates/network/ports/noop.yaml
-  OS::TripleO::Network::Ports::ControlPlaneVipPort: /root/templates/deployed-server/deployed-neutron-port.yaml
   OS::TripleO::Network::Ports::ControlPlanePort: /root/templates/deployed-server/deployed-neutron-port.yaml
   OS::TripleO::Compute::Net::SoftwareConfig: /root/templates/net-config-standalone.yaml
   OS::TripleO::Services::CACerts: OS::Heat::None

--- a/standalone-central.sh
+++ b/standalone-central.sh
@@ -47,8 +47,8 @@ fi
 sudo openstack tripleo deploy \
   --templates ~/templates \
   --local-ip=$IP/$NETMASK \
-  -e ~/templates/environments/standalone.yaml \
   -r ~/templates/roles/Standalone.yaml \
+  -e ~/templates/environments/standalone/standalone-tripleo.yaml \
   -e $HOME/containers-prepare-parameters.yaml \
   -e $HOME/standalone_parameters.yaml \
   --output-dir $HOME \

--- a/standalone-central.sh
+++ b/standalone-central.sh
@@ -49,7 +49,6 @@ sudo openstack tripleo deploy \
   --local-ip=$IP/$NETMASK \
   -r ~/templates/roles/Standalone.yaml \
   -e ~/templates/environments/standalone/standalone-tripleo.yaml \
-  -e ~/edge/environments/standalone-edge.yaml \
   -e $HOME/containers-prepare-parameters.yaml \
   -e $HOME/standalone_parameters.yaml \
   --output-dir $HOME \

--- a/standalone-central.sh
+++ b/standalone-central.sh
@@ -49,6 +49,7 @@ sudo openstack tripleo deploy \
   --local-ip=$IP/$NETMASK \
   -r ~/templates/roles/Standalone.yaml \
   -e ~/templates/environments/standalone/standalone-tripleo.yaml \
+  -e ~/edge/environments/standalone-edge.yaml \
   -e $HOME/containers-prepare-parameters.yaml \
   -e $HOME/standalone_parameters.yaml \
   --output-dir $HOME \

--- a/standalone-edge.sh
+++ b/standalone-edge.sh
@@ -49,6 +49,7 @@ sudo openstack tripleo deploy \
   --local-ip=$IP/$NETMASK \
   -r ~/edge/roles/Standalone-Compute.yaml \
   -e ~/templates/environments/standalone/standalone-tripleo.yaml \
+  -e ~/edge/environments/standalone-edge.yaml \
   -e ~/containers-prepare-parameters.yaml \
   -e ~/standalone_parameters.yaml \
   -e ~/export_control_plane/passwords.yaml \
@@ -58,9 +59,6 @@ sudo openstack tripleo deploy \
   -e ~/export_control_plane/oslo.yaml \
   --output-dir $HOME \
   --standalone $@
-
-# get rid of this...
-#  -e ~/edge/environments/standalone-edge.yaml \
 
 #  -e ~/templates/environments/ceph-ansible/ceph-ansible.yaml \
 #  -e ~/edge/environments/ceph_parameters.yaml \

--- a/standalone-edge.sh
+++ b/standalone-edge.sh
@@ -47,9 +47,8 @@ fi
 sudo openstack tripleo deploy \
   --templates ~/templates \
   --local-ip=$IP/$NETMASK \
-  -e ~/templates/environments/standalone.yaml \
   -r ~/edge/roles/Standalone-Compute.yaml \
-  -e ~/edge/environments/standalone-edge.yaml \
+  -e ~/templates/environments/standalone/standalone-tripleo.yaml \
   -e ~/containers-prepare-parameters.yaml \
   -e ~/standalone_parameters.yaml \
   -e ~/export_control_plane/passwords.yaml \
@@ -60,5 +59,9 @@ sudo openstack tripleo deploy \
   --output-dir $HOME \
   --standalone $@
 
+# get rid of this...
+#  -e ~/edge/environments/standalone-edge.yaml \
+
 #  -e ~/templates/environments/ceph-ansible/ceph-ansible.yaml \
 #  -e ~/edge/environments/ceph_parameters.yaml \
+


### PR DESCRIPTION
- In git_clone.sh checkout the testing branch by default
- set tht_review to "" as original patch merged
- Switch from tht/environments/standalone.yaml tht/environments/standalone-tripleo.yaml
- Clean up standalone-edge.yaml so it doesn't redundantly override overrides already in standalone-tripleo.yaml
- Add inventory_{one,two} to make testing easier:

1. This creates three nodes ready to be tested, but only tests with the first two:

time (ansible-playbook -i inventory.yml clone.yml; ansible-playbook -i inventory_one.yml deploy_and_test.yml -vv)

2. This deploys a second compute node using the third node without changing the first:

time ansible-playbook -i inventory_two.yml deploy_and_test.yml -vv --skip-tags controller

This can be useful for testing a change affecting only compute nodes
without redeploying the controller node.